### PR TITLE
CUI-7426 In ColumnViewItem only set tabIndex on render if it is not already set

### DIFF
--- a/coral-component-columnview/src/scripts/ColumnViewItem.js
+++ b/coral-component-columnview/src/scripts/ColumnViewItem.js
@@ -361,7 +361,10 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
 
     this.id = this.id || commons.getUID();
 
-    this.tabIndex = this.active || this.selected ? 0 : -1;
+    // only set tabIndex if it is not already set
+    if (!this.hasAttribute('tabindex')) {
+      this.tabIndex = this.active || this.selected ? 0 : -1;
+    }
     
     // Default reflected attributes
     if (!this._variant) { this.variant = variant.DEFAULT; }


### PR DESCRIPTION
## Description

Fixes a race condition where `ColumnView._ensureTabbableItem` sets tabIndex before the ColumnViewItem renders, in which case, the first selectable item should already have a tabIndex attribute that should not be overwritten with `-1` if the item is neither active nor selected.

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7426 and adobe#137

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
